### PR TITLE
Fix missing Eye icon imports

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,6 +3,7 @@ import {
   User, Upload, MessageCircle, Calendar, Search,
   LogOut, FileText, Image, Video, Download, Trash2,
   Send, Bot, Users, Home, Bell, BookOpen,
+  Eye, EyeOff,
 
 } from 'lucide-react';
 


### PR DESCRIPTION
## Summary
- import `Eye` and `EyeOff` icons used for password visibility toggles

## Testing
- `npm run lint`
- `npx tsc --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_6845871eb10083308b33c32dccfaa674