### PR TITLE
Add animated mobile sidebar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.0.0",
       "dependencies": {
         "express": "^4.19.2",
+        "framer-motion": "^12.16.0",
         "lucide-react": "^0.344.0",
         "node-fetch": "^3.3.2",
         "react": "^18.3.1",
@@ -2764,6 +2765,33 @@
         "url": "https://github.com/sponsors/rawify"
       }
     },
+    "node_modules/framer-motion": {
+      "version": "12.16.0",
+      "resolved": "https://registry.npmjs.org/framer-motion/-/framer-motion-12.16.0.tgz",
+      "integrity": "sha512-xryrmD4jSBQrS2IkMdcTmiS4aSKckbS7kLDCuhUn9110SQKG1w3zlq1RTqCblewg+ZYe+m3sdtzQA6cRwo5g8Q==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-dom": "^12.16.0",
+        "motion-utils": "^12.12.1",
+        "tslib": "^2.4.0"
+      },
+      "peerDependencies": {
+        "@emotion/is-prop-valid": "*",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@emotion/is-prop-valid": {
+          "optional": true
+        },
+        "react": {
+          "optional": true
+        },
+        "react-dom": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/fresh": {
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/fresh/-/fresh-0.5.2.tgz",
@@ -3388,6 +3416,21 @@
       "engines": {
         "node": ">=16 || 14 >=14.17"
       }
+    },
+    "node_modules/motion-dom": {
+      "version": "12.16.0",
+      "resolved": "https://registry.npmjs.org/motion-dom/-/motion-dom-12.16.0.tgz",
+      "integrity": "sha512-Z2nGwWrrdH4egLEtgYMCEN4V2qQt1qxlKy/uV7w691ztyA41Q5Rbn0KNGbsNVDZr9E8PD2IOQ3hSccRnB6xWzw==",
+      "license": "MIT",
+      "dependencies": {
+        "motion-utils": "^12.12.1"
+      }
+    },
+    "node_modules/motion-utils": {
+      "version": "12.12.1",
+      "resolved": "https://registry.npmjs.org/motion-utils/-/motion-utils-12.12.1.tgz",
+      "integrity": "sha512-f9qiqUHm7hWSLlNW8gS9pisnsN7CRFRD58vNjptKdsqFLpkVnX00TNeD6Q0d27V9KzT7ySFyK1TZ/DShfVOv6w==",
+      "license": "MIT"
     },
     "node_modules/ms": {
       "version": "2.1.3",
@@ -4606,6 +4649,12 @@
       "resolved": "https://registry.npmjs.org/ts-interface-checker/-/ts-interface-checker-0.1.13.tgz",
       "integrity": "sha512-Y/arvbn+rrz3JCKl9C4kVNfTfSm2/mEp5FSz5EsZSANGPSlQrpRI5M4PKF+mJnE52jOO90PnPSc3Ur3bTQw0gA==",
       "dev": true
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "license": "0BSD"
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -11,12 +11,13 @@
     "server": "node src/server.js"
   },
   "dependencies": {
+    "express": "^4.19.2",
+    "framer-motion": "^12.16.0",
     "lucide-react": "^0.344.0",
+    "node-fetch": "^3.3.2",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
-    "react-turnstile": "^1.1.4",
-    "express": "^4.19.2",
-    "node-fetch": "^3.3.2"
+    "react-turnstile": "^1.1.4"
   },
   "devDependencies": {
     "@eslint/js": "^9.9.1",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,10 +3,11 @@ import {
   User, Upload, MessageCircle, Calendar, Search,
   LogOut, FileText, Image, Video, Download, Trash2,
   Send, Bot, Users, Home, Bell, BookOpen,
-  EyeOff, CheckCircle, Clock,
+  EyeOff, CheckCircle, Clock, Menu,
 
 } from 'lucide-react';
 import { CloudflareGate } from './components/Security/CloudflareGate';
+import { MobileSidebar } from './components/MobileSidebar';
 
 // Types
 interface User {
@@ -113,6 +114,7 @@ const App: React.FC = () => {
   });
   const [aiChatTyping, setAiChatTyping] = useState(false);
   const [classAiTyping, setClassAiTyping] = useState(false);
+  const [sidebarOpen, setSidebarOpen] = useState(false);
   
   // Refs
   const chatEndRef = useRef<HTMLDivElement>(null);
@@ -120,6 +122,7 @@ const App: React.FC = () => {
   const fileInputRef = useRef<HTMLInputElement>(null);
 
   // Constants
+  const years = ['1e', '2e', '3e', '4e', '5e', '6e'];
   const streams = [
     'Latijn', 'Wetenschappen', 'Economie', 'Humane Wetenschappen', 
     'Moderne Talen', 'STEM', 'Grieks-Latijn', 'Sport', 
@@ -956,6 +959,12 @@ const App: React.FC = () => {
   // Main Dashboard
   return (
     <div className="min-h-screen bg-gray-50">
+      <MobileSidebar
+        open={sidebarOpen}
+        onClose={() => setSidebarOpen(false)}
+        years={years}
+        streams={streams}
+      />
       {/* Header */}
       <div className="bg-white shadow-sm border-b">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
@@ -969,6 +978,13 @@ const App: React.FC = () => {
             </div>
             
             <div className="flex items-center space-x-4">
+              <button
+                className="md:hidden"
+                onClick={() => setSidebarOpen(true)}
+                aria-label="Open menu"
+              >
+                <Menu className="w-6 h-6 text-gray-600" />
+              </button>
               <div className="relative">
                 <Bell className="w-6 h-6 text-gray-600" />
                 {notifications.filter(n => !n.read).length > 0 && (
@@ -1000,7 +1016,7 @@ const App: React.FC = () => {
       </div>
 
       {/* Navigation */}
-      <div className="bg-white border-b">
+      <div className="bg-white border-b hidden md:block">
         <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
           <nav className="flex space-x-8">
             {[

--- a/src/components/MobileSidebar.tsx
+++ b/src/components/MobileSidebar.tsx
@@ -1,0 +1,54 @@
+import React from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { X } from 'lucide-react';
+
+interface MobileSidebarProps {
+  open: boolean;
+  onClose: () => void;
+  years: string[];
+  streams: string[];
+}
+
+export const MobileSidebar: React.FC<MobileSidebarProps> = ({ open, onClose, years, streams }) => (
+  <AnimatePresence>
+    {open && (
+      <>
+        <motion.div
+          className="fixed inset-0 bg-black bg-opacity-30 z-40"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          onClick={onClose}
+        />
+        <motion.aside
+          className="fixed inset-y-0 left-0 w-64 bg-white z-50 shadow-lg p-4 overflow-y-auto"
+          initial={{ x: '-100%' }}
+          animate={{ x: 0 }}
+          exit={{ x: '-100%' }}
+          transition={{ type: 'tween' }}
+        >
+          <div className="flex items-center justify-between mb-4">
+            <h2 className="text-lg font-semibold">Chatrooms</h2>
+            <button onClick={onClose} aria-label="Close sidebar">
+              <X className="w-5 h-5" />
+            </button>
+          </div>
+          <div className="space-y-4">
+            {years.map((year) => (
+              <div key={year}>
+                <h3 className="text-sm font-medium text-gray-700 mb-1">{year} middelbaar</h3>
+                <ul className="pl-4 space-y-1">
+                  {streams.map((stream) => (
+                    <li key={`${year}-${stream}`} className="text-sm text-gray-600">
+                      {stream}
+                    </li>
+                  ))}
+                </ul>
+              </div>
+            ))}
+          </div>
+        </motion.aside>
+      </>
+    )}
+  </AnimatePresence>
+);


### PR DESCRIPTION
## Summary
- install framer-motion
- show hamburger menu in header
- hide navigation bar on mobile and open sidebar instead
- list all class chatrooms in MobileSidebar component

## Testing
- `npm run lint`
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_6846d65dd8348330ba8d3028487ea353